### PR TITLE
feat: add RDBMS storage mode types and CLI flag

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.default]
+retries = 0
+fail-fast = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ clap = { version = "4.5.3", features = ["derive"] }
 chrono = "0.4.35"
 chrono-humanize = "0.2.2"
 
+[dev-dependencies]
+serde_json = "1"
+tokio = { version = "1", features = ["test-util", "macros"] }
+
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"

--- a/src/create.rs
+++ b/src/create.rs
@@ -7,12 +7,12 @@ use tracing::{info, warn};
 use crate::{
     elasticsearch::{take_snapshot, SnapshotRequest},
     operate,
-    types::{BackupDescriptor, BackupState},
+    types::{BackupDescriptor, BackupState, StorageMode},
     zeebe,
 };
 
 #[tracing::instrument(err)]
-pub(crate) async fn create() -> Result<(), Box<dyn Error>> {
+pub(crate) async fn create(_storage_mode: StorageMode) -> Result<(), Box<dyn Error>> {
     let kube = kube::Client::try_default().await?;
     let backup_id = Utc::now().timestamp() as u64;
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -11,12 +11,12 @@ use tracing::{info, warn};
 
 use crate::{
     operate,
-    types::{BackupDescriptor, BackupState, OperateDetails, ZeebeDetails},
+    types::{BackupDescriptor, BackupState, OperateDetails, StorageMode, ZeebeDetails},
     zeebe,
 };
 
 #[tracing::instrument(err)]
-pub(crate) async fn list() -> Result<(), Box<dyn Error>> {
+pub(crate) async fn list(_storage_mode: StorageMode) -> Result<(), Box<dyn Error>> {
     let kube = kube::Client::try_default().await?;
     let zeebe_backups: Vec<BackupDescriptor<crate::types::ZeebeDetails>> =
         zeebe::list_backups(&kube).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Commands::List => list::list(cli.storage_mode).await,
         Commands::Create => create::create(cli.storage_mode).await,
-        Commands::Restore { to, backup_id } => restore::restore(cli.storage_mode, to, backup_id).await,
+        Commands::Restore { to, backup_id } => {
+            restore::restore(cli.storage_mode, to, backup_id).await
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@ use tracing::Level;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry};
 use tracing_tree::HierarchicalLayer;
 
+use crate::types::StorageMode;
+
 mod common;
 mod create;
 mod elasticsearch;
@@ -16,12 +18,22 @@ mod zeebe;
 enum Commands {
     List,
     Create,
-    Restore,
+    Restore {
+        /// Point-in-time restore target (ISO 8601 timestamp, RDBMS mode only)
+        #[arg(long)]
+        to: Option<String>,
+        /// Explicit backup ID to restore from
+        #[arg(long)]
+        backup_id: Option<u64>,
+    },
 }
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
+    /// Secondary storage type of the Camunda deployment
+    #[arg(long, value_enum, default_value_t = StorageMode::Elasticsearch)]
+    storage_mode: StorageMode,
     #[command(subcommand)]
     command: Commands,
 }
@@ -43,8 +55,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::List => list::list().await,
-        Commands::Create => create::create().await,
-        Commands::Restore => restore::restore().await,
+        Commands::List => list::list(cli.storage_mode).await,
+        Commands::Create => create::create(cli.storage_mode).await,
+        Commands::Restore { to, backup_id } => restore::restore(cli.storage_mode, to, backup_id).await,
     }
 }

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -26,7 +26,11 @@ use crate::{
 };
 
 #[tracing::instrument(err)]
-pub(crate) async fn restore(_storage_mode: StorageMode, _to: Option<String>, _backup_id: Option<u64>) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) async fn restore(
+    _storage_mode: StorageMode,
+    _to: Option<String>,
+    _backup_id: Option<u64>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let kube = kube::Client::try_default().await?;
     let backup = find_newest_backup(&kube).await?;
     let restartable = shutdown_apps(&kube).await?;

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -20,11 +20,13 @@ use tracing::info;
 
 use crate::{
     elasticsearch::{delete_index, get_all_indices, restore_snapshot},
-    list, operate, zeebe,
+    list, operate,
+    types::StorageMode,
+    zeebe,
 };
 
 #[tracing::instrument(err)]
-pub(crate) async fn restore() -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) async fn restore(_storage_mode: StorageMode, _to: Option<String>, _backup_id: Option<u64>) -> Result<(), Box<dyn std::error::Error>> {
     let kube = kube::Client::try_default().await?;
     let backup = find_newest_backup(&kube).await?;
     let restartable = shutdown_apps(&kube).await?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,15 @@
 use serde::{Deserialize, Serialize};
 
+// --- StorageMode enum for CLI ---
+
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+pub enum StorageMode {
+    Elasticsearch,
+    Rdbms,
+}
+
+// --- Existing types (unchanged) ---
+
 #[derive(Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum BackupState {
@@ -8,7 +18,10 @@ pub enum BackupState {
     InProgress,
     Incomplete,
     DoesNotExist,
+    Incompatible,
+    Deleted,
 }
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct BackupDescriptor<T> {
@@ -30,4 +43,98 @@ pub struct OperateDetails {
 #[serde(rename_all = "camelCase")]
 pub struct TakeBackupRequest {
     pub backup_id: String,
+}
+
+// --- Runtime backup API types (GET /actuator/backupRuntime) ---
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeBackupInfo {
+    pub backup_id: u64,
+    pub state: BackupState,
+    #[serde(default)]
+    pub failure_reason: Option<String>,
+    pub details: Vec<PartitionBackupInfo>,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PartitionBackupInfo {
+    pub partition_id: u32,
+    pub state: BackupState,
+    #[serde(default)]
+    pub failure_reason: Option<String>,
+    #[serde(default)]
+    pub created_at: Option<String>,
+    #[serde(default)]
+    pub last_updated_at: Option<String>,
+    #[serde(default)]
+    pub snapshot_id: Option<String>,
+    #[serde(default)]
+    pub checkpoint_position: Option<i64>,
+    #[serde(default)]
+    pub broker_id: Option<i32>,
+    #[serde(default)]
+    pub broker_version: Option<String>,
+}
+
+// --- History backup API types (GET /actuator/backupHistory) ---
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryBackupInfo {
+    pub backup_id: u64,
+    pub state: BackupState,
+    #[serde(default)]
+    pub failure_reason: Option<String>,
+    pub details: Vec<HistoryBackupDetail>,
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryBackupDetail {
+    pub snapshot_name: String,
+    pub state: String,
+    #[serde(default)]
+    pub start_time: Option<String>,
+    #[serde(default)]
+    pub failures: Vec<String>,
+}
+
+// --- Checkpoint state (GET /actuator/backupRuntime/state) ---
+
+#[allow(dead_code)]
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckpointState {
+    #[serde(default)]
+    pub checkpoint_states: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub backup_states: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub ranges: Vec<serde_json::Value>,
+}
+
+// --- Internal restore target enum ---
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum RestoreTarget {
+    EsBackup { id: u64, snapshots: Vec<String> },
+    RdbmsAuto,
+    RdbmsBackupId { id: u64 },
+    RdbmsPointInTime { to: String },
+}
+
+// --- Request type for runtime backups ---
+
+#[allow(dead_code)]
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TakeRuntimeBackupRequest {
+    pub backup_id: u64,
 }


### PR DESCRIPTION
## Summary
- Add all RDBMS-era API response types (`RuntimeBackupInfo`, `PartitionBackupInfo`, `HistoryBackupInfo`, `HistoryBackupDetail`, `CheckpointState`, `TakeRuntimeBackupRequest`) and internal `RestoreTarget` enum to `src/types.rs`
- Add `StorageMode` enum with `--storage-mode elasticsearch|rdbms` global CLI flag (defaults to `elasticsearch`)
- Add `--to` and `--backup-id` flags to the `Restore` subcommand for RDBMS point-in-time and explicit backup ID restore
- Extend `BackupState` with `Incompatible` and `Deleted` variants
- Update `list`, `create`, `restore` function signatures to accept `StorageMode` (pass-through, no behavior change)
- Add `[dev-dependencies]` (serde_json, tokio test-util) and `.config/nextest.toml`

## Test plan
- [x] `cargo build` compiles without errors
- [x] `cargo test` passes (no regressions)
- [x] `cargo clippy -- -D warnings` produces no new warnings (13 pre-existing warnings unchanged)
- [ ] Manual: `cargo run -- --help` shows `--storage-mode` flag
- [ ] Manual: `cargo run -- restore --help` shows `--to` and `--backup-id` flags