### PR TITLE
feat: add RDBMS mode for list command with tests

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -11,44 +11,99 @@ use tracing::{info, warn};
 
 use crate::{
     operate,
-    types::{BackupDescriptor, BackupState, OperateDetails, StorageMode, ZeebeDetails},
+    types::{
+        BackupDescriptor, BackupState, OperateDetails, RuntimeBackupInfo, StorageMode, ZeebeDetails,
+    },
     zeebe,
 };
 
-#[tracing::instrument(err)]
-pub(crate) async fn list(_storage_mode: StorageMode) -> Result<(), Box<dyn Error>> {
+/// Trait for types that carry a backup ID and state, used to unify stats printing.
+trait BackupEntry {
+    fn backup_id(&self) -> u64;
+    fn state(&self) -> BackupState;
+}
+
+impl<T> BackupEntry for BackupDescriptor<T> {
+    fn backup_id(&self) -> u64 {
+        self.backup_id
+    }
+    fn state(&self) -> BackupState {
+        self.state
+    }
+}
+
+impl BackupEntry for RuntimeBackupInfo {
+    fn backup_id(&self) -> u64 {
+        self.backup_id
+    }
+    fn state(&self) -> BackupState {
+        self.state
+    }
+}
+
+pub(crate) async fn list(storage_mode: StorageMode) -> Result<(), Box<dyn Error>> {
     let kube = kube::Client::try_default().await?;
-    let zeebe_backups: Vec<BackupDescriptor<crate::types::ZeebeDetails>> =
-        zeebe::list_backups(&kube).await?;
-    let operate_backups = operate::list_backups(&kube).await?;
+    match storage_mode {
+        StorageMode::Elasticsearch => list_es(&kube).await,
+        StorageMode::Rdbms => list_rdbms(&kube).await,
+    }
+}
+
+#[tracing::instrument(skip(kube), err)]
+async fn list_es(kube: &kube::Client) -> Result<(), Box<dyn Error>> {
+    let zeebe_backups: Vec<BackupDescriptor<ZeebeDetails>> = zeebe::list_backups(kube).await?;
+    let operate_backups = operate::list_backups(kube).await?;
 
     tracing::info_span!("Zeebe").in_scope(|| {
-        print_backup_stats(&zeebe_backups);
+        print_stats("backups", &zeebe_backups);
     });
     tracing::info_span!("Operate").in_scope(|| {
-        print_backup_stats(&operate_backups);
+        print_stats("backups", &operate_backups);
     });
 
     match find_most_recent_usable(&zeebe_backups, &operate_backups) {
-        Some(backup_id) => {
-            info!("The most recent usable backup is {}", backup_id);
-            match Utc.timestamp_opt(backup_id as i64, 0) {
-                LocalResult::Single(date) => {
-                    info!(
-                        "This backup was created {} at {}",
-                        HumanTime::from(date),
-                        date
-                    );
-                }
-                _ => (),
-            }
+        Some(id) => log_backup_timestamp("The most recent usable backup", id),
+        None => warn!("No usable backups found"),
+    }
+
+    Ok(())
+}
+
+#[tracing::instrument(skip(kube), err)]
+async fn list_rdbms(kube: &kube::Client) -> Result<(), Box<dyn Error>> {
+    let runtime_backups = zeebe::list_runtime_backups(kube).await?;
+
+    tracing::info_span!("Runtime Backups").in_scope(|| {
+        print_stats("runtime backups", &runtime_backups);
+    });
+
+    match find_most_recent_runtime_backup(&runtime_backups) {
+        Some(id) => log_backup_timestamp("The most recent completed runtime backup", id),
+        None => warn!("No completed runtime backups found"),
+    }
+
+    // Show checkpoint state
+    match zeebe::get_backup_state(kube).await {
+        Ok(state) => {
+            info!("Backup ranges: {} partition(s)", state.ranges.len());
         }
-        None => {
-            warn!("No usable backups found");
+        Err(e) => {
+            warn!("Could not fetch backup state: {}", e);
         }
     }
 
     Ok(())
+}
+
+fn log_backup_timestamp(label: &str, backup_id: u64) {
+    info!("{} is {}", label, backup_id);
+    if let LocalResult::Single(date) = Utc.timestamp_opt(backup_id as i64, 0) {
+        info!(
+            "This backup was created {} at {}",
+            HumanTime::from(date),
+            date
+        );
+    }
 }
 
 #[tracing::instrument(level = "debug")]
@@ -57,12 +112,12 @@ pub fn find_most_recent_usable(
     operate: &Vec<BackupDescriptor<OperateDetails>>,
 ) -> Option<u64> {
     let zeebe: BTreeSet<u64> = zeebe
-        .into_iter()
+        .iter()
         .filter(|b| b.state == BackupState::Completed)
         .map(|d| d.backup_id)
         .collect();
     let operate: BTreeSet<u64> = operate
-        .into_iter()
+        .iter()
         .filter(|b| b.state == BackupState::Completed)
         .map(|d| d.backup_id)
         .collect();
@@ -70,28 +125,156 @@ pub fn find_most_recent_usable(
     zeebe.intersection(&operate).last().copied()
 }
 
-fn print_backup_stats<T>(backups: &Vec<BackupDescriptor<T>>) {
-    let backups_by_state = backups.iter().fold(
-        HashMap::<BackupState, Vec<&BackupDescriptor<T>>>::new(),
-        |mut map, backup| {
-            map.entry(backup.state).or_default().push(backup);
-            map
-        },
-    );
+pub fn find_most_recent_runtime_backup(backups: &[RuntimeBackupInfo]) -> Option<u64> {
+    backups
+        .iter()
+        .filter(|b| b.state == BackupState::Completed)
+        .map(|b| b.backup_id)
+        .max()
+}
 
-    for (state, mut backups) in backups_by_state {
-        backups.sort_by_key(|d| d.backup_id);
-        let most_recent = backups
+fn print_stats<T: BackupEntry>(label: &str, backups: &[T]) {
+    let backups_by_state =
+        backups
+            .iter()
+            .fold(HashMap::<BackupState, Vec<&T>>::new(), |mut map, backup| {
+                map.entry(backup.state()).or_default().push(backup);
+                map
+            });
+
+    for (state, mut entries) in backups_by_state {
+        entries.sort_by_key(|e| e.backup_id());
+        let most_recent = entries
             .iter()
             .rev()
             .take(3)
-            .map(|d| d.backup_id.to_string())
+            .map(|e| e.backup_id().to_string())
             .collect::<Vec<_>>();
         info!(
-            "{} backups {:?}: {}, ...",
-            backups.len(),
+            "{} {} {:?}: {}, ...",
+            entries.len(),
+            label,
             state,
             most_recent.join(", ")
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        BackupDescriptor, BackupState, OperateDetails, RuntimeBackupInfo, ZeebeDetails,
+    };
+
+    #[test]
+    fn test_find_most_recent_usable_empty() {
+        let zeebe: Vec<BackupDescriptor<ZeebeDetails>> = vec![];
+        let operate: Vec<BackupDescriptor<OperateDetails>> = vec![];
+        assert_eq!(find_most_recent_usable(&zeebe, &operate), None);
+    }
+
+    #[test]
+    fn test_find_most_recent_usable_no_overlap() {
+        let zeebe = vec![BackupDescriptor {
+            backup_id: 1,
+            state: BackupState::Completed,
+            details: vec![],
+        }];
+        let operate = vec![BackupDescriptor {
+            backup_id: 2,
+            state: BackupState::Completed,
+            details: vec![],
+        }];
+        assert_eq!(find_most_recent_usable(&zeebe, &operate), None);
+    }
+
+    #[test]
+    fn test_find_most_recent_usable_with_overlap() {
+        let zeebe = vec![
+            BackupDescriptor {
+                backup_id: 1,
+                state: BackupState::Completed,
+                details: vec![],
+            },
+            BackupDescriptor {
+                backup_id: 2,
+                state: BackupState::Completed,
+                details: vec![],
+            },
+        ];
+        let operate = vec![
+            BackupDescriptor {
+                backup_id: 2,
+                state: BackupState::Completed,
+                details: vec![],
+            },
+            BackupDescriptor {
+                backup_id: 3,
+                state: BackupState::Completed,
+                details: vec![],
+            },
+        ];
+        assert_eq!(find_most_recent_usable(&zeebe, &operate), Some(2));
+    }
+
+    #[test]
+    fn test_find_most_recent_usable_ignores_non_completed() {
+        let zeebe = vec![
+            BackupDescriptor {
+                backup_id: 1,
+                state: BackupState::Completed,
+                details: vec![],
+            },
+            BackupDescriptor {
+                backup_id: 2,
+                state: BackupState::Failed,
+                details: vec![],
+            },
+        ];
+        let operate = vec![
+            BackupDescriptor {
+                backup_id: 1,
+                state: BackupState::Completed,
+                details: vec![],
+            },
+            BackupDescriptor {
+                backup_id: 2,
+                state: BackupState::Completed,
+                details: vec![],
+            },
+        ];
+        assert_eq!(find_most_recent_usable(&zeebe, &operate), Some(1));
+    }
+
+    #[test]
+    fn test_find_most_recent_runtime_backup_empty() {
+        let backups: Vec<RuntimeBackupInfo> = vec![];
+        assert_eq!(find_most_recent_runtime_backup(&backups), None);
+    }
+
+    #[test]
+    fn test_find_most_recent_runtime_backup_finds_latest_completed() {
+        let backups = vec![
+            RuntimeBackupInfo {
+                backup_id: 100,
+                state: BackupState::Completed,
+                failure_reason: None,
+                details: vec![],
+            },
+            RuntimeBackupInfo {
+                backup_id: 200,
+                state: BackupState::Failed,
+                failure_reason: None,
+                details: vec![],
+            },
+            RuntimeBackupInfo {
+                backup_id: 150,
+                state: BackupState::Completed,
+                failure_reason: None,
+                details: vec![],
+            },
+        ];
+        assert_eq!(find_most_recent_runtime_backup(&backups), Some(150));
     }
 }


### PR DESCRIPTION
## Summary
- Adds RDBMS mode dispatch to the `list` command
- Queries runtime backups via `/actuator/backupRuntime` and shows checkpoint state
- Introduces `BackupEntry` trait to unify backup stats printing across ES and RDBMS modes
- Adds `find_most_recent_runtime_backup()` function
- 6 unit tests for list logic (both ES and RDBMS paths)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` — 6 tests pass
- [ ] Manual test against RDBMS-based Camunda 8.9+ deployment